### PR TITLE
Adding LICENSE file as a data file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
             'semantic-ui-2.2.10/*',
         ],
     },
+    data_files = [("", ["LICENSE"])],
     url = 'https://github.com/djungelorm/sphinx-tabs',
     license = 'MIT',
     description = 'Tab views for Sphinx',


### PR DESCRIPTION
This commit includes the LICENSE file as a data_file in setup.py,
this way the source distribution tarball will also include the file.