### PR TITLE
Scope :last-child margin rules to .tab

### DIFF
--- a/sphinx_tabs/tabs.css
+++ b/sphinx_tabs/tabs.css
@@ -27,9 +27,9 @@
 }
 
 .tab .wy-plain-list-disc:last-child,
-.rst-content .section ul:last-child,
-.rst-content .toctree-wrapper ul:last-child,
-article ul:last-child {
+.tab .rst-content .section ul:last-child,
+.tab .rst-content .toctree-wrapper ul:last-child,
+.tab article ul:last-child {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
When these rules are not scoped to .tab, they influence various other parts of the documentation:

<img width="565" alt="image" src="https://user-images.githubusercontent.com/283441/50638622-c7816800-0f5e-11e9-9656-5c9d870d41d9.png">
