### PR TITLE
Mark the extension as parallel-safe

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -341,3 +341,8 @@ def setup(app):
                 app.add_javascript(path)
     app.connect('html-page-context', update_context)
     app.connect('build-finished', copy_assets)
+
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
This has been tested in [godotengine/godot-docs](https://github.com/godotengine/godot-docs) (https://github.com/godotengine/godot-docs/pull/2669), in which it seems to be working well so far.

This closes #32.